### PR TITLE
BUG: fix improperly escaped quotes

### DIFF
--- a/repo-utils/create-builtin-suite-yaml.py
+++ b/repo-utils/create-builtin-suite-yaml.py
@@ -26,14 +26,14 @@ def main(distro, categories, destination):
         'auto_tool_repositories': {
             'name_template': '{{ tool_id }}',
             'description_template': 'Galaxy tool for QIIME 2 builtin:'
-                                    ' "{{ tool_name }}".'
+                                    ' \'{{ tool_name }}\'.'
         },
         'suite': {
             'name': suite_name,
             'description': f'Galaxy suite for QIIME 2 builtins for the'
-                           f' "{distro}" distribution.',
+                           f' \'{distro}\' distribution.',
             'long_description': f'Galaxy suite for QIIME 2 builtins for the'
-                                f' "{distro}" distribution.'
+                                f' \'{distro}\' distribution.'
         }
     }
     with open(os.path.join(destination, '.shed.yml'), 'w') as fh:

--- a/repo-utils/create-plugin-suite-yaml.py
+++ b/repo-utils/create-plugin-suite-yaml.py
@@ -28,12 +28,12 @@ def main(plugin_id, categories, destination):
         'auto_tool_repositories': {
             'name_template': '{{ tool_id }}',
             'description_template': 'Galaxy tool for QIIME 2 action:'
-                                    ' "{{tool_name}}".'
+                                    ' \'{{tool_name}}\'.'
         },
         'suite': {
             'name': suite_name,
             'description': f'Galaxy suite for QIIME 2 plugin: '
-                           f'"qiime2 {plugin.name}".'
+                           f'\'qiime2 {plugin.name}\'.'
                            f' {plugin.short_description}',
             'long_description': plugin.description
         }

--- a/repo-utils/render.py
+++ b/repo-utils/render.py
@@ -87,7 +87,6 @@ def setup_docker(image, tools_dir):
 
 
 def render_distro(distro_definition, depends, collections_dir):
-    return
     print(f"DISTRO RENDER: {distro_definition['name']}", flush=True)
 
     categories = set()


### PR DESCRIPTION
Turns out planemo won't escape double quotes in the shed.yml file correctly, generating bad XML like this:

```xml
<repositories description="Galaxy suite for QIIME 2 plugin: "qiime2 alignment". Plugin for generating and manipulating alignments.">  <repository owner="q2d2" name="qiime2__alignment__mafft" />
  <repository owner="q2d2" name="qiime2__alignment__mafft_add" />
  <repository owner="q2d2" name="qiime2__alignment__mask" />
</repositories>
```

Hopefully that's the reason for:
```
 Could not update suite_qiime2__alignment
Unexpected HTTP status code: 500: {"err_msg": "Exception attempting to parse /srv/toolshed-repos/test/007/repo_7351/repository_dependencies.xml: attributes construct error, line 1, column 62 (repository_dependencies.xml, line 1)"}
```