### PR TITLE
MISC: minor improvements after testing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,10 +12,14 @@ on:
       # The rendering has 2 phases: 1st is updating distros which issues a PR,
       # that PR has the changes which are then tested by this action.
       - 'distros.yaml'
+      - 'repo-utils/**'
+      - 'README.md'
   pull_request:
     branches: [main]
     paths-ignore:
       - 'distros.yaml'
+      - 'repo-utils/**'
+      - 'README.md'
 # MODIFIED END
 env:
   GALAXY_FORK: galaxyproject
@@ -355,13 +359,13 @@ jobs:
         repository-list: ${{ needs.setup.outputs.repository-list }}
         shed-target: testtoolshed
         shed-key: ${{ secrets.TTS_API_KEY }}
-#    - name: Deploy on toolshed
-#      uses: galaxyproject/planemo-ci-action@v1
-#      with:
-#        mode: deploy
-#        repository-list: ${{ needs.setup.outputs.repository-list }}
-#        shed-target: toolshed
-#        shed-key: ${{ secrets.TS_API_KEY }}
+    - name: Deploy on toolshed
+      uses: galaxyproject/planemo-ci-action@v1
+      with:
+        mode: deploy
+        repository-list: ${{ needs.setup.outputs.repository-list }}
+        shed-target: toolshed
+        shed-key: ${{ secrets.TS_API_KEY }}
 
   determine-success:
     name: Check workflow success

--- a/.github/workflows/render_tools.yml
+++ b/.github/workflows/render_tools.yml
@@ -7,11 +7,13 @@ on:
     paths-ignore:
       - 'tool_collections/**'
       - 'tools/**'
+      - 'README.md'
   pull_request:
     branches: [main]
     paths-ignore:
       - 'tool_collections/**'
       - 'tools/**'
+      - 'README.md'
 
 jobs:
   render:
@@ -31,13 +33,28 @@ jobs:
           conda install pyyaml
           make render
 
-      - name: create PR
+      - name: create tools PR
         uses: peter-evans/create-pull-request@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
+          add-paths: tools
           token: ${{ secrets.Q2D2_TOKEN }}
-          commit-message: Updated tools
+          commit-message: Update Galaxy Tools
           committer: q2d2 <q2d2.noreply@gmail.com>
           author: q2d2 <q2d2.noreply@gmail.com>
           title: Automated re-render of Galaxy Tools
           body: Results of `make render` on `main`
+
+      - name: create collections PR
+        uses: peter-evans/create-pull-request@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          add-paths: tool_collections
+          token: ${{ secrets.Q2D2_TOKEN }}
+          commit-message: Update Galaxy Tool Collections
+          committer: q2d2 <q2d2.noreply@gmail.com>
+          author: q2d2 <q2d2.noreply@gmail.com>
+          title: Automated re-render of Galaxy Tool Collections (wait to merge)
+          body: |
+            Results of `make render` on `main`.
+            DO NOT MERGE until all tools in the sibling PR have successfully deployed.

--- a/repo-utils/render.py
+++ b/repo-utils/render.py
@@ -88,14 +88,13 @@ def setup_docker(image, tools_dir):
 
 
 def render_distro(distro_definition, depends, collections_dir):
-    return  # someday this will work.
     print(f"DISTRO RENDER: {distro_definition['name']}", flush=True)
 
     categories = set()
     for s in depends:
         categories.update(s['categories'])
 
-    name = f"suite_qiime2dist_{distro_definition['name']}"
+    name = f"suite_qiime2_{distro_definition['name']}"
     shed = {
         'owner': 'q2d2',
         'categories': list(categories),
@@ -142,6 +141,12 @@ def render_plugin(plugin, distro_definition, cached_plugins, tools_dir):
     else:
         suite_dir = os.path.relpath(paths[0], tools_dir).split(os.path.sep)[0]
         out_dir = os.path.join(tools_dir, suite_dir)
+
+    # Fix crazy output names when installed on toolshed
+    # TODO: fix in q2galaxy
+    subprocess.run(
+        "sed -i 's/${tool.id}/${tool.name}/g' " + out_dir + '/*.xml',
+        check=True, shell=True)
 
     if docker_image is not None:
         for path in paths:

--- a/repo-utils/swap-in-docker.py
+++ b/repo-utils/swap-in-docker.py
@@ -16,7 +16,7 @@ def main(tool_fp, docker_image):
 
     root.replace(root.find('requirements'), new_reqs)
     # HACK: set correct profile and hack version
-    root.set('version', root.get('version') + '.1')
+    root.set('version', root.get('version') + '.2')
     root.set('profile', '22.05')
 
     xml.indent(tool, ' ' * 4)


### PR DESCRIPTION
After experimenting with the tools downloaded from the test toolshed, it's very clear that `${tool.id}` should not be used in output names, it's really weird.
![image](https://user-images.githubusercontent.com/3976804/187015776-d13e88c5-793d-47fc-bf55-12370764f695.png)

Upshot, it's easy to fix, and otherwise everything appears to be working.

This PR also enables the "real" toolshed, however I haven't added the API key to secrets yet, so don't merge the re-rendered PRs until I get to that.