### PR TITLE
map formats and artifact classes to EDAM (types and data, respectively?)

### DIFF
--- a/tools/suite_qiime2_core__tools/qiime2_core__tools__import.xml
+++ b/tools/suite_qiime2_core__tools/qiime2_core__tools__import.xml
@@ -939,7 +939,7 @@ write(json.dumps(inputs))
                                     <option value="individual">Associate individual files</option>
                                 </param>
                                 <when value="collection">
-                                    <param name="elements" type="data_collection" collection_type="list" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information. Elements must match regex: .+_.+_R[12]_001\.fastq\.gz"/>
+                                    <param name="elements" type="data_collection" collection_type="list" format="fastqsanger.gz" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information. Elements must match regex: .+_.+_R[12]_001\.fastq\.gz"/>
                                     <conditional name="__q2galaxy__GUI__cond__add_ext__">
                                         <param name="__q2galaxy__GUI__select__ext_pick__" type="select" label="Append an extension?" help="This is needed if your element identifiers lack one.">
                                             <option value="no">No, use element identifiers as is</option>
@@ -956,7 +956,7 @@ write(json.dumps(inputs))
                                         <param name="name" type="text" help="Filename to import the data as. Must match regex: .+_.+_R[12]_001\.fastq\.gz">
                                             <validator type="regex" message="This filename doesn't match the regex.">.+_.+_R[12]_001\.fastq\.gz</validator>
                                         </param>
-                                        <param name="data" type="data" format="data" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information."/>
+                                        <param name="data" type="data" format="fastqsanger.gz" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information."/>
                                     </repeat>
                                 </when>
                             </conditional>
@@ -1147,7 +1147,7 @@ write(json.dumps(inputs))
                                     <option value="individual">Associate individual files</option>
                                 </param>
                                 <when value="collection">
-                                    <param name="elements" type="data_collection" collection_type="list" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information. Elements must match regex: .+_.+_R[12]_001\.fastq\.gz"/>
+                                    <param name="elements" type="data_collection" collection_type="list" format="fastqsanger.gz" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information. Elements must match regex: .+_.+_R[12]_001\.fastq\.gz"/>
                                     <conditional name="__q2galaxy__GUI__cond__add_ext__">
                                         <param name="__q2galaxy__GUI__select__ext_pick__" type="select" label="Append an extension?" help="This is needed if your element identifiers lack one.">
                                             <option value="no">No, use element identifiers as is</option>
@@ -1164,7 +1164,7 @@ write(json.dumps(inputs))
                                         <param name="name" type="text" help="Filename to import the data as. Must match regex: .+_.+_R[12]_001\.fastq\.gz">
                                             <validator type="regex" message="This filename doesn't match the regex.">.+_.+_R[12]_001\.fastq\.gz</validator>
                                         </param>
-                                        <param name="data" type="data" format="data" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information."/>
+                                        <param name="data" type="data" format="fastqsanger.gz" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information."/>
                                     </repeat>
                                 </when>
                             </conditional>
@@ -1313,7 +1313,7 @@ write(json.dumps(inputs))
                                     <option value="individual">Associate individual files</option>
                                 </param>
                                 <when value="collection">
-                                    <param name="elements" type="data_collection" collection_type="list" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information. Elements must match regex: .+_.+_R[12]_001\.fastq\.gz"/>
+                                    <param name="elements" type="data_collection" collection_type="list" format="fastqsanger.gz" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information. Elements must match regex: .+_.+_R[12]_001\.fastq\.gz"/>
                                     <conditional name="__q2galaxy__GUI__cond__add_ext__">
                                         <param name="__q2galaxy__GUI__select__ext_pick__" type="select" label="Append an extension?" help="This is needed if your element identifiers lack one.">
                                             <option value="no">No, use element identifiers as is</option>
@@ -1330,7 +1330,7 @@ write(json.dumps(inputs))
                                         <param name="name" type="text" help="Filename to import the data as. Must match regex: .+_.+_R[12]_001\.fastq\.gz">
                                             <validator type="regex" message="This filename doesn't match the regex.">.+_.+_R[12]_001\.fastq\.gz</validator>
                                         </param>
-                                        <param name="data" type="data" format="data" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information."/>
+                                        <param name="data" type="data" format="fastqsanger.gz" help="This data should be formatted as a FastqGzFormat. See the documentation below for more information."/>
                                     </repeat>
                                 </when>
                             </conditional>


### PR DESCRIPTION
If possible input parameters and collections should always set the `format` attribute. I exemplify this here for some `fastq.gz` inputs. Probably the implementation should not be done here in this repo?

For fastq.gz Galaxy has a few datatypes, fastq.gz, fastqillumina.gz, and `fastqsanger.gz` (and colorspace fastqsanger). `fastq.gz` would allow all of them. 

Let me know if you need help with mapping other qiime2 datatypes to Galaxy data types.

